### PR TITLE
Issue #335 moving core to the profile.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,6 @@
         "drupal/config_direct_save": "^1.0",
         "drupal/config_installer": "^1.0",
         "drupal/console": "^1",
-        "drupal/core-composer-scaffold": "^8.8.1",
-        "drupal/core-recommended": "^8.8",
         "drupal/migrate_plus": "^5.1",
         "drupal/migrate_tools": "^5.0",
         "drupal/migrate_upgrade": "^3.2",
@@ -165,6 +163,16 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3"
+        },
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "zaporylie/composer-drupal-optimizations": true,
+            "drupal/console-extend-plugin": false,
+            "oomphinc/composer-installers-extender": true,
+            "rvtraveller/qs-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "pantheon-systems/drupal-integrations": "^8",
         "pantheon-systems/quicksilver-pushback": "^2",
         "rvtraveller/qs-composer-installer": "^1.1",
-        "wri/wri_sites": "^v1.0",
+        "wri/wri_sites": "^v1.0.24",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
For https://github.com/wri/WRIN/issues/355. Moves where drupal core is located, updates the composer.json syntax to work with composer 2.2. Locks the wri_sites version to the one where https://github.com/wri/wri_sites/pull/44 will be merged.